### PR TITLE
fix: restore routes on tab and router

### DIFF
--- a/client/src/components/Tabs/TabsContain/TabArtistContain.tsx
+++ b/client/src/components/Tabs/TabsContain/TabArtistContain.tsx
@@ -13,7 +13,7 @@ export default function TabArtist() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_URL}/api/artists`)
+    fetch(`${import.meta.env.VITE_API_URL}/api/artist`)
       .then((res) => res.json())
       .then((data) => {
         setArtists(data);

--- a/client/src/components/Tabs/TabsContain/TabUserContain.tsx
+++ b/client/src/components/Tabs/TabsContain/TabUserContain.tsx
@@ -17,7 +17,7 @@ export default function TabUser() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_URL}/api/user`)
+    fetch(`${import.meta.env.VITE_API_URL}/api/users`)
       .then((res) => res.json())
       .then((data) => {
         setUsers(data);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -13,13 +13,16 @@ if (process.env.CLIENT_URL != null) {
   app.use(cors({ origin: [process.env.CLIENT_URL] }));
 }
 
-//app.use(express.json());
+app.use(express.json());
 
 const publicFolderPath = path.join(__dirname, "../../server/public");
 
 if (fs.existsSync(publicFolderPath)) {
   app.use(express.static(publicFolderPath));
 }
+
+import router from "./router";
+app.use(router);
 
 import discoveredRouter from "./modules/discovered/discoveredRouter";
 app.use("/api/discovered", discoveredRouter);

--- a/server/src/modules/user/usersActions.ts
+++ b/server/src/modules/user/usersActions.ts
@@ -118,4 +118,4 @@ const add: RequestHandler = async (req, res, next) => {
   }
 };
 
-export default { browse, read, add, hashPassword };
+export default { browse, read, add, hashPassword, login };

--- a/server/src/modules/user/usersRepository.ts
+++ b/server/src/modules/user/usersRepository.ts
@@ -49,7 +49,7 @@ class UsersRepository {
     );
 
     // Return the first row of the result, which represents the user
-    return (rows as User[])[0] ?? null;
+    return rows as User[];
   }
 
   async readByEmailWithPassword(email: string) {

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { upload } from "./middlewares/multer";
+// import { upload } from "./middlewares/multer";
 import artistActions from "./modules/artist/artistActions";
 import artworkActions from "./modules/artwork/artworkActions";
 import discoveredActions from "./modules/discovered/discoveredActions";
@@ -14,7 +14,7 @@ const router = express.Router();
 
 // Define item-related routes
 
-router.post("/api/discovered", upload.single("photo"), discoveredActions.add);
+// router.post("/api/discovered", upload.single("photo"), discoveredActions.add);
 router.use("/discovered", discoveredRouter);
 
 router.get("/api/users", usersActions.browse);
@@ -24,11 +24,10 @@ router.post(
   usersActions.hashPassword,
   usersActions.add,
 );
-router.post("/api/user", usersActions.hashPassword, usersActions.add);
 
-router.get("/api/artists", artistActions.browse);
-router.get("/api/artists/:id", artistActions.read);
-router.post("/api/artists", artistActions.add);
+router.get("/api/artist", artistActions.browse);
+router.get("/api/artist/:id", artistActions.read);
+router.post("/api/artist", artistActions.add);
 
 router.get("/api/artworks", artworkActions.browse);
 router.get("/api/artworks/:id", artworkActions.read);


### PR DESCRIPTION
J'ai rétablie les routes qui font fonctionner les onglets artistes et utilisateurs en remettant les bonne nomination.

J'avais tester si "multer" causait des problèmes en commentant les lignes dans le router, vous pouvez les décommenter cela fonctionne quand même avec ce n'était pas lui le problème. 

J'ai également rétablie l'import du router dans app qui avait disparu (???)